### PR TITLE
Switch analytics to self-hosted Umami

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -28,7 +28,7 @@ params:
   readingTime: true # Show estimated reading time
   wordCount: true # Show word count
   toc: true # Enable Table of Contents by default in posts
-  analytics: { google: { id: G-6C126MZNGT } }
+  analytics: { umami: { id: REPLACE_ME, host: https://analytics.mirceanton.com } }
   search: { enable: true, maxResults: 20 }
 
   comments:
@@ -71,12 +71,6 @@ sitemap:
   changefreq: weekly
   priority: 0.5
   filename: sitemap.xml
-
-# Privacy settings
-privacy:
-  googleAnalytics:
-    anonymizeIP: true
-    respectDoNotTrack: true
 
 # ===============================================================================================
 # Markup configuration

--- a/layouts/partials/analytics/umami.html
+++ b/layouts/partials/analytics/umami.html
@@ -1,0 +1,5 @@
+<script
+  defer
+  src="{{ site.Params.analytics.umami.host }}/script.js"
+  data-website-id="{{ site.Params.analytics.umami.id }}"
+></script>


### PR DESCRIPTION
The Chirpy theme only ships built-in partials for Google Analytics,
Fathom, and Cloudflare. Add a custom analytics/umami.html partial
(theme resolves layouts/partials/analytics/<platform>.html dynamically
based on params.analytics keys) and point the site at a self-hosted
Umami instance, replacing Google Analytics.

The website ID is a placeholder until the Umami instance is deployed
and the site is registered with it.